### PR TITLE
feat(models): toggleable LightGBM GPU support (DZ4-02)

### DIFF
--- a/dropzilla/config.py
+++ b/dropzilla/config.py
@@ -32,6 +32,7 @@ FEATURE_CONFIG = {
 
 # --- Model Training Configuration ---
 MODEL_CONFIG = {
+    "use_gpu": False,
     "model_filename": "dropzilla_v4_lgbm.pkl",
     "cv_n_splits": 5,
     "cv_embargo_pct": 0.01,

--- a/dropzilla/models.py
+++ b/dropzilla/models.py
@@ -12,6 +12,7 @@ import pandas as pd
 from typing import Dict, Any, Tuple, List
 from sklearn.metrics import roc_auc_score
 from hyperopt import fmin, tpe, hp, Trials, STATUS_OK
+from dropzilla.config import MODEL_CONFIG
 
 def train_lightgbm_model(X_train: pd.DataFrame,
                          y_train: pd.Series,
@@ -32,6 +33,13 @@ def train_lightgbm_model(X_train: pd.DataFrame,
         'verbose': -1,
     }
     # --- END FIX ---
+
+    if MODEL_CONFIG.get("use_gpu"):
+        default_params.update({
+            "device_type": "gpu",
+            "gpu_platform_id": 0,
+            "gpu_device_id": 0,
+        })
 
     if params:
         default_params.update(params)

--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -9,7 +9,7 @@ import joblib
 from datetime import datetime, timedelta
 
 # --- Local Application Imports ---
-from dropzilla.config import POLYGON_API_KEY, DATA_CONFIG, FEATURE_CONFIG
+from dropzilla.config import POLYGON_API_KEY, DATA_CONFIG, FEATURE_CONFIG, MODEL_CONFIG
 from dropzilla.data import PolygonDataClient
 from dropzilla.features import calculate_features
 from dropzilla.context import get_market_regimes
@@ -144,5 +144,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run Dropzilla v4 Financial Backtest.")
     parser.add_argument("--model", type=str, default="dropzilla_v4_lgbm.pkl", help="Path to the model artifact file.")
     parser.add_argument("--threshold", type=float, default=0.55, help="The minimum confidence score to simulate a trade.")
+    parser.add_argument("--use_gpu", action="store_true", help="Enable GPU acceleration")
     args = parser.parse_args()
+    MODEL_CONFIG["use_gpu"] = args.use_gpu
     run_backtest(args.model, args.threshold)

--- a/scripts/run_training.py
+++ b/scripts/run_training.py
@@ -183,7 +183,10 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run Dropzilla v4.1 Unified Training Pipeline.")
     parser.add_argument("--tickers", type=str, help="Comma-separated list of tickers to train on. Defaults to the diversified list.")
     parser.add_argument("--model_name", type=str, required=True, help="Filename for the new model artifact (e.g., all_weather_v1.pkl).")
+    parser.add_argument("--use_gpu", action="store_true", help="Enable GPU acceleration")
     args = parser.parse_args()
+
+    MODEL_CONFIG["use_gpu"] = args.use_gpu
     
     if args.tickers:
         ticker_list = [ticker.strip().upper() for ticker in args.tickers.split(',')]


### PR DESCRIPTION
## Summary
- add `use_gpu` flag to model config
- enable GPU parameters in training helper when flag is set
- wire GPU toggle into training and backtest CLI scripts

## Testing
- `pip install -q -r requirements.txt`
- `pip install hmmlearn -q`
- `pytest -q` *(fails: ImportError: cannot import name 'smooth_probabilities_kalman')*

------
https://chatgpt.com/codex/tasks/task_e_686c543fa3b0832fa3550e1cddfa9014