### PR TITLE
chore(env): enable CUDA toolchain and GPU-enabled LightGBM (DZ4-01)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,20 @@ jobs:
     - name: Run tests with pytest
       run: |
         pytest
+
+  gpu-check:
+    runs-on: [self-hosted, gpu]
+    continue-on-error: true
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Verify GPU build
+      run: python scripts/verify_gpu.py

--- a/docs/SETUP_GPU.md
+++ b/docs/SETUP_GPU.md
@@ -1,0 +1,39 @@
+# GPU Setup Guide
+
+The following steps outline how to prepare a WSL2 Ubuntu 22.04 environment with CUDA 12.9 for running Dropzilla v4 with GPU acceleration.
+
+1. **Install NVIDIA Drivers**
+   - Ensure the latest Windows NVIDIA drivers are installed.
+   - Enable the WSL2 feature for NVIDIA in Windows.
+
+2. **Install CUDA Toolkit 12.9**
+   - Inside the Ubuntu shell, add the CUDA repository:
+     ```bash
+     wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-ubuntu2204.pin
+     sudo mv cuda-ubuntu2204.pin /etc/apt/preferences.d/cuda-repository-pin-600
+     sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
+     echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /" | sudo tee /etc/apt/sources.list.d/cuda.list
+     sudo apt update && sudo apt install -y cuda-toolkit-12-9
+     ```
+   - Reboot the WSL2 instance after installation.
+
+3. **Create and Activate a Python Environment**
+   ```bash
+   python3 -m venv ~/.venvs/dz-gpu
+   source ~/.venvs/dz-gpu/bin/activate
+   ```
+
+4. **Install Python Dependencies**
+   ```bash
+   pip install --upgrade pip
+   pip install -r requirements.txt
+   ```
+
+5. **Verify the GPU Build**
+   Run the verification script:
+   ```bash
+   python scripts/verify_gpu.py
+   ```
+   A successful setup prints:
+   `LightGBM built with CUDA ✅`
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,9 @@ joblib
 arch
 
 #Modeling & Optimization
-lightgbm
+# lightgbm  # CPU build (fallback)
+lightgbm==4.3.0 --extra-index-url https://pypi.nvidia.com  # GPU build
+cupy-cuda12x==13.0.0
 catboost
 hyperopt
 shap

--- a/scripts/verify_gpu.py
+++ b/scripts/verify_gpu.py
@@ -1,0 +1,16 @@
+"""Verify GPU-enabled LightGBM build."""
+
+import sys
+
+try:
+    import cupy  # noqa: F401
+    import lightgbm as lgb
+except Exception as exc:  # pragma: no cover - simple sanity check
+    print(f"Import failed: {exc}")
+    sys.exit(1)
+
+if hasattr(lgb, "DaskDeviceQuantileDMatrix"):
+    print("LightGBM built with CUDA ✅")
+else:
+    print("LightGBM built without CUDA ❌")
+    sys.exit(1)


### PR DESCRIPTION
## Summary
- use CUDA-enabled LightGBM wheel and CuPy
- document GPU setup for WSL2 Ubuntu 22.04
- add `verify_gpu.py` helper
- run GPU verification job on self-hosted GPU runner

## Testing
- `pytest -q` *(fails: cannot import name 'smooth_probabilities_kalman')*
- `python scripts/verify_gpu.py` *(fails: No module named 'cupy')*

------
https://chatgpt.com/codex/tasks/task_e_686c542fff50832f9c8208f250acf6e4