### PR TITLE
feat(backtest): propagate GPU flag & CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,16 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs_on }}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        include:
+          - python-version: "3.10"
+            runs_on: ubuntu-latest
+          - python-version: "3.11"
+            runs_on: ubuntu-latest
+          - python-version: "3.12"
+            runs_on: [self-hosted, gpu]
 
     steps:
     - name: Checkout repository
@@ -36,19 +42,19 @@ jobs:
       run: |
         pytest
 
-  gpu-check:
+  verify_gpu:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    if: contains(matrix.os, 'ubuntu')
     runs-on: [self-hosted, gpu]
+    timeout-minutes: 15
     continue-on-error: true
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-    - name: Verify GPU build
-      run: python scripts/verify_gpu.py
+        python-version: '3.12'
+    - run: pip install -r requirements.txt
+    - run: python scripts/verify_gpu.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Dropzilla v4: An Institutional-Grade Intraday Signal Engine
 **Last Updated:** July 7, 2025
 [GPU ✔ | CUDA speed-up x5.5](docs/GPU_BENCHMARK.md)
+* GPU quick-start → [GPU guide](docs/GPU_GUIDE.md)
 
 ## 1. Project Overview & Status
 

--- a/docs/GPU_GUIDE.md
+++ b/docs/GPU_GUIDE.md
@@ -1,0 +1,30 @@
+# GPU Quick-Start
+
+This guide explains how to verify your LightGBM installation uses CUDA and how to run a GPU-accelerated back-test.
+
+## Verify the build
+
+Run the verification script:
+
+```bash
+python scripts/verify_gpu.py
+```
+
+If CUDA support is detected the script prints:
+`LightGBM built with CUDA ✅`
+
+## Run a GPU back-test
+
+Execute the back-test with GPU enabled:
+
+```bash
+python scripts/run_backtest.py --tickers AAPL MSFT --use_gpu
+```
+
+When a CUDA-enabled wheel is installed, LightGBM logs will show `CUDA`.
+
+## Environment tips
+
+- Works well under WSL 2 with NVIDIA drivers and CUDA 12.9.
+- Use `max_bin=255` for fastest GPU training.
+- Confirm `POLYGON_API_KEY` is set before running the scripts.

--- a/dropzilla/config.py
+++ b/dropzilla/config.py
@@ -3,6 +3,15 @@ Centralized configuration for the Dropzilla v4 application.
 """
 import os
 from dotenv import load_dotenv
+import lightgbm as lgb
+
+
+def _gpu_available() -> bool:
+    """Return True if LightGBM was built with CUDA support."""
+    try:
+        return "cuda" in lgb.get_device_name(0).lower()
+    except Exception:
+        return False
 
 # Load environment variables from a .env file if it exists
 load_dotenv()
@@ -32,7 +41,7 @@ FEATURE_CONFIG = {
 
 # --- Model Training Configuration ---
 MODEL_CONFIG = {
-    "use_gpu": False,
+    "use_gpu": _gpu_available(),
     "model_filename": "dropzilla_v4_lgbm.pkl",
     "cv_n_splits": 5,
     "cv_embargo_pct": 0.01,

--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -144,7 +144,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run Dropzilla v4 Financial Backtest.")
     parser.add_argument("--model", type=str, default="dropzilla_v4_lgbm.pkl", help="Path to the model artifact file.")
     parser.add_argument("--threshold", type=float, default=0.55, help="The minimum confidence score to simulate a trade.")
-    parser.add_argument("--use_gpu", action="store_true", help="Enable GPU acceleration")
+    parser.add_argument("--use_gpu", action="store_true",
+                        help="Force GPU acceleration if installed")
     args = parser.parse_args()
-    MODEL_CONFIG["use_gpu"] = args.use_gpu
+    MODEL_CONFIG["use_gpu"] = args.use_gpu or MODEL_CONFIG["use_gpu"]
     run_backtest(args.model, args.threshold)

--- a/scripts/run_prediction.py
+++ b/scripts/run_prediction.py
@@ -71,7 +71,12 @@ def get_prediction(symbol: str, model_artifact_path: str) -> dict | None:
     latest_data = pd.merge_asof(latest_data.sort_index(), sar_scores.to_frame(name='sar_score'), left_index=True, right_index=True, direction='backward')
 
     # Market Regime
-    spy_df = data_client.get_aggs("SPY", from_date=(from_date - timedelta(days=50)).strftime('%Y-%m-%d'), to_date.strftime('%Y-%m-%d'), timespan='day')
+    spy_df = data_client.get_aggs(
+        "SPY",
+        from_date=(from_date - timedelta(days=50)).strftime('%Y-%m-%d'),
+        to_date=to_date.strftime('%Y-%m-%d'),
+        timespan='day'
+    )
     if spy_df is not None and not spy_df.empty:
         spy_df['market_regime'] = get_market_regimes(spy_df)
         latest_data = pd.merge_asof(latest_data.sort_index(), spy_df[['market_regime']].dropna(), left_index=True, right_index=True, direction='backward')


### PR DESCRIPTION
## Summary
- auto-detect CUDA in configuration
- wire `--use_gpu` flag in `run_backtest.py`
- add GPU quick-start guide and link from README
- update CI workflow with optional self-hosted GPU job
- fix prediction arg order for mypy

## Testing
- `pytest -q`
- `mypy . --ignore-missing-imports` *(fails: Found 24 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686caf83ed78832f9241fd1f2af145ca