### PR TITLE
feat(pipeline): gpu-aware model naming

### DIFF
--- a/docs/GPU_GUIDE.md
+++ b/docs/GPU_GUIDE.md
@@ -28,3 +28,15 @@ When a CUDA-enabled wheel is installed, LightGBM logs will show `CUDA`.
 - Works well under WSL 2 with NVIDIA drivers and CUDA 12.9.
 - Use `max_bin=255` for fastest GPU training.
 - Confirm `POLYGON_API_KEY` is set before running the scripts.
+
+## Training & inference file naming
+
+Models trained with GPU acceleration are suffixed with `_gpu.pkl` while CPU
+models use `_cpu.pkl`.
+
+```bash
+python scripts/run_training.py --use_gpu --model_name dropzilla_v4_lgbm.pkl
+# writes dropzilla_v4_lgbm_gpu.pkl
+
+python scripts/run_prediction.py --gpu --model dropzilla_v4_lgbm.pkl
+```

--- a/dropzilla/config.py
+++ b/dropzilla/config.py
@@ -45,7 +45,9 @@ MODEL_CONFIG = {
     "model_filename": "dropzilla_v4_lgbm.pkl",
     "cv_n_splits": 5,
     "cv_embargo_pct": 0.01,
-    "optimization_max_evals": 50
+    "optimization_max_evals": 50,
+    "suffix_gpu": "_gpu",
+    "suffix_cpu": "_cpu",
 }
 
 # --- Labeling Configuration ---

--- a/scripts/run_prediction.py
+++ b/scripts/run_prediction.py
@@ -9,19 +9,20 @@ if not hasattr(np, "NaN"):
 # --- Standard Library Imports ---
 import argparse
 from datetime import datetime, timedelta
+import os
 
 # --- Third-Party Imports ---
 import pandas as pd
 import joblib
 
 # --- Local Application Imports ---
-from dropzilla.config import POLYGON_API_KEY, FEATURE_CONFIG
+from dropzilla.config import POLYGON_API_KEY, FEATURE_CONFIG, MODEL_CONFIG
 from dropzilla.data import PolygonDataClient
 from dropzilla.features import calculate_features
 from dropzilla.context import get_market_regimes
 from dropzilla.correlation import get_systemic_absorption_ratio
 
-def get_prediction(symbol: str, model_artifact_path: str) -> dict | None:
+def get_prediction(symbol: str, model_artifact_path: str, use_gpu: bool = False) -> dict | None:
     """
     Generates a drop prediction and confidence score for a single symbol.
     """
@@ -34,6 +35,11 @@ def get_prediction(symbol: str, model_artifact_path: str) -> dict | None:
         meta_model = artifact['meta_model']
         features_to_use = artifact['features_to_use']
         meta_features_to_use = artifact['meta_model_features']
+        if use_gpu:
+            try:
+                primary_model.set_params(device_type="cuda")
+            except Exception:
+                pass
     except (FileNotFoundError, KeyError) as e:
         print(f"Error loading model artifact: {e}")
         return None
@@ -123,6 +129,29 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run Dropzilla v4 Live Prediction.")
     parser.add_argument("symbol", type=str, help="The stock ticker symbol to predict (e.g., AAPL).")
     parser.add_argument("--model", type=str, default="dropzilla_v4_lgbm.pkl", help="Path to the model artifact file.")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--gpu", action="store_true", help="Force loading the GPU model")
+    group.add_argument("--cpu", action="store_true", help="Force loading the CPU model")
     args = parser.parse_args()
 
-    get_prediction(args.symbol.upper(), args.model)
+    base, ext = os.path.splitext(args.model)
+    if args.gpu:
+        target = base + MODEL_CONFIG["suffix_gpu"] + ext
+        use_gpu = True
+    elif args.cpu:
+        target = base + MODEL_CONFIG["suffix_cpu"] + ext
+        use_gpu = False
+    else:
+        gpu_path = base + MODEL_CONFIG["suffix_gpu"] + ext
+        cpu_path = base + MODEL_CONFIG["suffix_cpu"] + ext
+        if os.path.exists(gpu_path):
+            target = gpu_path
+            use_gpu = True
+        elif os.path.exists(cpu_path):
+            target = cpu_path
+            use_gpu = False
+        else:
+            target = args.model
+            use_gpu = False
+
+    get_prediction(args.symbol.upper(), target, use_gpu=use_gpu)

--- a/scripts/run_training.py
+++ b/scripts/run_training.py
@@ -13,6 +13,7 @@ train a general-purpose, "all-weather" signal model.
 # --- Standard Library Imports ---
 from datetime import datetime, timedelta, timezone # <-- FIX: Import timezone
 import argparse
+import os
 
 # --- Third-Party Imports ---
 import pandas as pd
@@ -187,10 +188,14 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     MODEL_CONFIG["use_gpu"] = args.use_gpu
-    
+
+    base, ext = os.path.splitext(args.model_name)
+    suffix = MODEL_CONFIG["suffix_gpu"] if MODEL_CONFIG["use_gpu"] else MODEL_CONFIG["suffix_cpu"]
+    artifact_path = base + suffix + ext
+
     if args.tickers:
         ticker_list = [ticker.strip().upper() for ticker in args.tickers.split(',')]
     else:
         ticker_list = DIVERSIFIED_UNIVERSE
 
-    main(tickers=ticker_list, model_name=args.model_name)
+    main(tickers=ticker_list, model_name=artifact_path)


### PR DESCRIPTION
## Summary
- extend `MODEL_CONFIG` with cpu/gpu suffixes
- save models with suffix according to hardware
- add GPU/CPU flags to prediction script and choose file
- note artifact naming in GPU guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cb73f8e7c832f9c877752a428ce9b